### PR TITLE
change dts-bundle-generator's generateDtsBundle usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = class DtsBundlePlugin {
             compilation.entrypoints.forEach(entrypoint => {
                 entrypoint.origins.forEach(element => {
                     if (runTest(this.test, element.request)) {
-                        const dts = generateDtsBundle(element.request);
+                        const dts = generateDtsBundle([{filePath: element.request}]);
                         const name = this.name;
                         const dtsName = loaderUtils.interpolateName(
                             {


### PR DESCRIPTION
In updated version `ts-declaration-webpack-plugin` (1.2.1), My webpack process is breaking.

With update(`1.2.0` to `1.2.1`), dependent `dts-bundle-generator` package version was changed `1.6.1` to `3.3.1`.

When I compared the `dts-bundle-generator`'s two versions(`1.6.1` to `3.3.1`), `generateDtsBundle` function parameter changed.

[1.6.1](https://github.com/timocov/dts-bundle-generator/blob/86051e248e9b1915ba83261787ac78366f6378c8/src/bundle-generator.ts#L49)
```ts
function generateDtsBundle(filePath: string, options: GenerationOptions = {}): string
```

[3.3.1](https://github.com/timocov/dts-bundle-generator/blob/ea8c3cd77d34c36e7cff1b9547e86da85ebe7dba/src/bundle-generator.ts#L115)
```ts
function generateDtsBundle(entries: ReadonlyArray<EntryPointConfig>, options: CompilationOptions = {}): string[]
```

`filePath` moved to `EntryPointConfig`'s property.

https://github.com/timocov/dts-bundle-generator/blob/ea8c3cd77d34c36e7cff1b9547e86da85ebe7dba/src/bundle-generator.ts#L99