### PR TITLE
Upgrading to work with Webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = class DtsBundlePlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
+    compiler.hooks.emit.tap('Emiter', (compilation, callback) => {
       compilation.entrypoints.forEach((entrypoint) => {
         entrypoint.origins.forEach((element) => {
           if (runTest(this.test, element.request)) {


### PR DESCRIPTION
Added a small change to make package work with Webpack 4.

See Migration Notes for Webpack 4:
https://medium.com/@sheng_di/webpack-4-migration-notes-65f2f4b79b8f